### PR TITLE
Add React login flow and protected routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Front-end Authentication
+
+This project includes example React components written in TypeScript for JWT-based login.
+
+- `Login.tsx` submits credentials to `/api/login` and stores the returned token and role under `his_token` and `his_role`.
+- `ProtectedRoute.tsx` checks these values and redirects to `/login` if they are missing or invalid.
+- A simple `logout` helper clears the stored values and navigates back to `/login`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
         "laravel-vite-plugin": "^1.0.0",
         "postcss": "^8.4.14",
         "tailwindcss": "^3.1.0",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.2",
+        "typescript": "^5.2.2",
+        "@types/react": "^18.2.14",
+        "@types/react-dom": "^18.2.7"
     }
 }

--- a/resources/js/components/Login.tsx
+++ b/resources/js/components/Login.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+const Login: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const { data } = await axios.post('/api/login', { email, password });
+      const { token, role } = data;
+      localStorage.setItem('his_token', token);
+      localStorage.setItem('his_role', role);
+      if (role === 'administrator') {
+        navigate('/homepage-admin');
+      } else {
+        alert('Access denied');
+      }
+    } catch (error: any) {
+      if (error.response && error.response.data && error.response.data.message) {
+        alert(error.response.data.message);
+      } else {
+        alert('Login failed');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="email">Email:</label>
+        <input
+          type="email"
+          id="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label htmlFor="password">Password:</label>
+        <input
+          type="password"
+          id="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      <button type="submit" disabled={loading}>
+        {loading ? 'Logging in...' : 'Login'}
+      </button>
+    </form>
+  );
+};
+
+export default Login;

--- a/resources/js/components/ProtectedRoute.tsx
+++ b/resources/js/components/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+interface ProtectedRouteProps {
+  roles?: string[];
+  children: React.ReactElement;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ roles, children }) => {
+  const token = localStorage.getItem('his_token');
+  const role = localStorage.getItem('his_role');
+
+  if (!token || !role || (roles && !roles.includes(role))) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/resources/js/components/logout.ts
+++ b/resources/js/components/logout.ts
@@ -1,0 +1,5 @@
+export function logout() {
+  localStorage.removeItem('his_token');
+  localStorage.removeItem('his_role');
+  window.location.href = '/login';
+}

--- a/resources/js/main.tsx
+++ b/resources/js/main.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import Login from './components/Login';
+import ProtectedRoute from './components/ProtectedRoute';
+
+const App = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route
+        path="/homepage-admin"
+        element={
+          <ProtectedRoute roles={["administrator"]}>
+            <div>Admin Home</div>
+          </ProtectedRoute>
+        }
+      />
+    </Routes>
+  </BrowserRouter>
+);
+
+ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(<App />);

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
             input: [
                 'resources/css/app.css',
                 'resources/js/app.js',
+                'resources/js/main.tsx',
             ],
             refresh: true,
         }),


### PR DESCRIPTION
## Summary
- add Login component that stores JWT and role
- add ProtectedRoute helper for route guarding
- add logout utility
- wire up main.tsx for example routes
- configure Vite to build new entry
- document front-end auth

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3e47f7c832b81e30c9a48d593d3